### PR TITLE
Fixed a bug in reloadTable()

### DIFF
--- a/BankApp/src/bankapp/MainMenu.java
+++ b/BankApp/src/bankapp/MainMenu.java
@@ -383,6 +383,12 @@ public class MainMenu extends javax.swing.JFrame {
     }
 
     private void reloadTable() {
+        DefaultTableModel model = (DefaultTableModel) accountTable.getModel();
+        // Deletes the rows from the highest index downwards, since deleting 
+        // from index 0 would shift all remaining rows to a lower index
+        for (int i = model.getRowCount() - 1; i >= 0; i--) {
+            model.removeRow(i); 
+        }
         for (Customer c : bank.getCustomers()) {
             addCustomerToTable(c);
         }


### PR DESCRIPTION
If you would open a new file, the clients in the file would be added to the table. So both the old clients + the new ones. Now you will reset the table so it's empty and then add the clients from the file.
